### PR TITLE
Disable colours when the output is not a terminal

### DIFF
--- a/beanstool.go
+++ b/beanstool.go
@@ -3,11 +3,17 @@ package main
 import (
 	"os"
 
+	"github.com/agtorre/gocolorize"
 	"github.com/jessevdk/go-flags"
 	"github.com/src-d/beanstool/cli"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 func main() {
+	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
+		gocolorize.SetPlain(true)
+	}
+
 	parser := flags.NewNamedParser("beanstool", flags.Default)
 	parser.AddCommand("stats", "print stats on all tubes", "", &cli.StatsCommand{})
 	parser.AddCommand("tail", "tails a tube and prints his content", "", &cli.TailCommand{})


### PR DESCRIPTION
I was watching a beanstalk tube by running `watch ./beanstool stats` and the colorised output was leading to output like this: `| ^[0;32m469     ^[0m |`.

This patch fixes that.