### PR TITLE
Fix double help message (stdout, stderr) fixes #12

### DIFF
--- a/beanstool.go
+++ b/beanstool.go
@@ -25,7 +25,7 @@ func main() {
 
 	_, err := parser.Parse()
 	if err != nil {
-		if _, ok := err.(*flags.Error); ok {
+		if flagErr, ok := err.(*flags.Error); ok && flagErr.Type != flags.ErrHelp {
 			parser.WriteHelp(os.Stdout)
 		}
 


### PR DESCRIPTION
  flags.Default contains flags.PrintErrors
  it automatically writes help message to os.Stderr when flag is given
  and error handling code was writing it to os.Stdout, again.