### PR TITLE
Fix command not added due to invalid default values

### DIFF
--- a/cli/delete.go
+++ b/cli/delete.go
@@ -7,8 +7,8 @@ import (
 type DeleteCommand struct {
 	Tube  string `short:"t" long:"tube" description:"tube to be delete." required:"true"`
 	State string `short:"" long:"state" description:"peek from 'buried', 'ready' or 'delayed' queues." default:"buried"`
-	Print bool   `short:"" long:"print" description:"prints the jobs after delete it." default:"true"`
-	Empty bool   `short:"" long:"empty" description:"delete all jobs with the given status in the given tube." default:"false"`
+	Print bool   `short:"" long:"print" description:"prints the jobs after delete it."`
+	Empty bool   `short:"" long:"empty" description:"delete all jobs with the given status in the given tube."`
 	Command
 }
 


### PR DESCRIPTION
Bool options are not allowed to have default values in jessevdk/go-flags.

Fixes #18 