### PR TITLE
Fixes #17

### DIFF
--- a/cli/stats.go
+++ b/cli/stats.go
@@ -51,13 +51,7 @@ func (c *StatsCommand) PrintStats() error {
 		"Name", "Buried", "Delayed", "Ready", "Reserved", "Urgent", "Waiting", "Total",
 	})
 
-	table.AddRow(c.buildLineFromTubeStats(DefaultTube, stats[DefaultTube]))
-
 	for _, t := range sortedKeys(stats) {
-		if t == DefaultTube {
-			continue
-		}
-
 		table.AddRow(c.buildLineFromTubeStats(t, stats[t]))
 	}
 


### PR DESCRIPTION
- Remove printing of Default Tube stats whether Getstats returns data for it or not
- Remove the special condition to continue for default tube

More details on https://github.com/src-d/beanstool/issues/17#issuecomment-426486670