### PR TITLE
Remove conflicting short flag -h

### DIFF
--- a/cli/command.go
+++ b/cli/command.go
@@ -11,7 +11,7 @@ var TitleStyle = gocolorize.NewColor("green")
 var InfoStyle = gocolorize.NewColor("yellow")
 
 type Command struct {
-	Host string `short:"h" long:"host" description:"beanstalkd host addr." required:"true" default:"localhost:11300"`
+	Host string `short:"" long:"host" description:"beanstalkd host addr." required:"true" default:"localhost:11300"`
 
 	conn *beanstalk.Conn
 }


### PR DESCRIPTION
The `-h` flag shows the usage message instead of working like `--host`:

```txt
$ beanstool stats -h localhost:11300
Usage:
  beanstool [OPTIONS] stats [stats-OPTIONS]

Help Options:
  -h, --help       Show this help message

[stats command options]
      -t, --tubes= tubes to be listed (separated by ,). By default all are listed
      -h, --host=  beanstalkd host addr. (default: localhost:11300)
[snip]
```

`beanstool stats --host localhost:11300` works as expected. This PR removes -h as alternative for --host.