### PR TITLE
Add short flags and fix conflicting host flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DEPENDENCIES =
 BASE_PATH := $(shell pwd)
 BUILD_PATH := $(BASE_PATH)/build
 VERSION ?= $(shell git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/')
-BUILD ?= $(shell date)
+BUILD ?= $(shell date --utc --rfc-3339=seconds | tr ' ' 'T')
 ASSETS := static
 
 # PACKAGES
@@ -27,7 +27,7 @@ all: test build
 
 build: dependencies
 	for cmd in $(COMMANDS); do \
-		$(GOCMD) build -ldflags "-X main.version $(VERSION) -X main.build \"$(BUILD)\"" $${cmd}.go; \
+		$(GOCMD) build -ldflags "-X main.version=$(VERSION) -X main.build=$(BUILD)" $${cmd}.go; \
 	done
 
 test: dependencies

--- a/cli/bury.go
+++ b/cli/bury.go
@@ -10,7 +10,7 @@ import (
 
 type BuryCommand struct {
 	Tube string `short:"t" long:"tube" description:"tube to bury jobs in." required:"true"`
-	Num  int    `short:"" long:"num" description:"number of jobs to bury."`
+	Num  int    `short:"n" long:"num" description:"number of jobs to bury."`
 	Command
 }
 

--- a/cli/command.go
+++ b/cli/command.go
@@ -11,7 +11,7 @@ var TitleStyle = gocolorize.NewColor("green")
 var InfoStyle = gocolorize.NewColor("yellow")
 
 type Command struct {
-	Host string `short:"h" long:"host" description:"beanstalkd host addr." required:"true" default:"localhost:11300"`
+	Host string `short:"H" long:"host" description:"beanstalkd host addr." required:"true" default:"localhost:11300"`
 
 	conn *beanstalk.Conn
 }

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -6,7 +6,7 @@ import (
 
 type DeleteCommand struct {
 	Tube  string `short:"t" long:"tube" description:"tube to be delete." required:"true"`
-	State string `short:"" long:"state" description:"peek from 'buried', 'ready' or 'delayed' queues." default:"buried"`
+	State string `short:"s" long:"state" description:"peek from 'buried', 'ready' or 'delayed' queues." default:"buried"`
 	Print bool   `short:"" long:"print" description:"prints the jobs after delete it."`
 	Empty bool   `short:"" long:"empty" description:"delete all jobs with the given status in the given tube."`
 	Command

--- a/cli/delete.go
+++ b/cli/delete.go
@@ -7,8 +7,8 @@ import (
 type DeleteCommand struct {
 	Tube  string `short:"t" long:"tube" description:"tube to be delete." required:"true"`
 	State string `short:"s" long:"state" description:"peek from 'buried', 'ready' or 'delayed' queues." default:"buried"`
-	Print bool   `short:"" long:"print" description:"prints the jobs after delete it."`
-	Empty bool   `short:"" long:"empty" description:"delete all jobs with the given status in the given tube."`
+	Print bool   `short:"p" long:"print" description:"prints the jobs after delete it."`
+	Empty bool   `short:"e" long:"empty" description:"delete all jobs with the given status in the given tube."`
 	Command
 }
 

--- a/cli/kick.go
+++ b/cli/kick.go
@@ -8,7 +8,7 @@ import (
 
 type KickCommand struct {
 	Tube string `short:"t" long:"tube" description:"tube to kick jobs in." required:"true"`
-	Num  int    `short:"" long:"num" description:"number of jobs to kick."`
+	Num  int    `short:"n" long:"num" description:"number of jobs to kick."`
 	Command
 }
 

--- a/cli/peek.go
+++ b/cli/peek.go
@@ -6,7 +6,7 @@ import (
 
 type PeekCommand struct {
 	Tube  string `short:"t" long:"tube" description:"tube to be tailed." required:"true"`
-	State string `short:"" long:"state" description:"peek from 'buried', 'ready' or 'delayed' queues." default:"buried"`
+	State string `short:"s" long:"state" description:"peek from 'buried', 'ready' or 'delayed' queues." default:"buried"`
 	Command
 }
 

--- a/cli/put.go
+++ b/cli/put.go
@@ -10,8 +10,8 @@ import (
 type PutCommand struct {
 	Tube     string        `short:"t" long:"tube" description:"tube to be tailed." required:"true"`
 	Body     string        `short:"b" long:"body" description:"plain text data for the job." required:"true"`
-	Priority uint32        `short:"" long:"priority" description:"priority for the job." default:"1024"`
-	Delay    time.Duration `short:"" long:"delay" description:"delay for the job." default:"0"`
+	Priority uint32        `short:"p" long:"priority" description:"priority for the job." default:"1024"`
+	Delay    time.Duration `short:"d" long:"delay" description:"delay for the job." default:"0"`
 	TTR      time.Duration `short:"" long:"ttr" description:"TTR for the job." default:"60"`
 
 	Command

--- a/cli/put.go
+++ b/cli/put.go
@@ -12,7 +12,7 @@ type PutCommand struct {
 	Body     string        `short:"b" long:"body" description:"plain text data for the job." required:"true"`
 	Priority uint32        `short:"p" long:"priority" description:"priority for the job." default:"1024"`
 	Delay    time.Duration `short:"d" long:"delay" description:"delay for the job." default:"0"`
-	TTR      time.Duration `short:"" long:"ttr" description:"TTR for the job." default:"60"`
+	TTR      time.Duration `short:"" long:"ttr" description:"TTR for the job." default:"60s"`
 
 	Command
 }

--- a/cli/tail.go
+++ b/cli/tail.go
@@ -13,7 +13,7 @@ var TooManyErrorsError = errors.New("Too many errors")
 
 type TailCommand struct {
 	Tube   string `short:"t" long:"tube" description:"tube to be tailed." required:"true"`
-	Action string `short:"" long:"action" description:"action to perform after reserver the job. (release, bury, delete)" default:"release"`
+	Action string `short:"a" long:"action" description:"action to perform after reserver the job. (release, bury, delete)" default:"release"`
 
 	Command
 }

--- a/cli/tail.go
+++ b/cli/tail.go
@@ -13,7 +13,7 @@ var TooManyErrorsError = errors.New("Too many errors")
 
 type TailCommand struct {
 	Tube   string `short:"t" long:"tube" description:"tube to be tailed." required:"true"`
-	Action string `short:"a" long:"action" description:"action to perform after reserver the job. (release, bury, delete)" default:"release"`
+	Action string `short:"a" long:"action" description:"action to perform after reserving the job. (release, bury, delete)" default:"release"`
 
 	Command
 }


### PR DESCRIPTION
This is a nice tool. But there are some minor usability annoyances with the input flags.

Addresses the `host=` flag short-form that conflicts with `--help`'s short form. Both are `-h` and `help` takes precedence. Get around this by specifying an alternative short-form for `host`. This is similar to #22.
Fix a typo in usage text.
Adds some other missing short-form flags.

I was careful to look for creating conflicts and couldn't find any new ones. Going through each subcommand's usage func shows that it still works. From what I understand, if there was a conflicting flag, then `beanstool <subcommand> -h` would output something like:
```
"Unknown command `delete'. Please specify one command of: bury, kick, peek, put, stats or tail
```
Which doesn't seem to happen.
Let me know what you think, thanks.
  